### PR TITLE
sort properties with mixed numeric, string, and null values

### DIFF
--- a/dist/amd/au-table.js
+++ b/dist/amd/au-table.js
@@ -199,6 +199,11 @@ define(["exports", "aurelia-framework"], function (exports, _aureliaFramework) {
         };
 
         AureliaTableCustomAttribute.prototype.doSort = function doSort(toSort, sortKey, sortOrder) {
+
+            var isNumeric = function isNumeric(n) {
+                return !isNaN(parseFloat(n)) && isFinite(n);
+            };
+
             toSort.sort(function (a, b) {
 
                 var val1 = void 0;
@@ -212,13 +217,16 @@ define(["exports", "aurelia-framework"], function (exports, _aureliaFramework) {
                     val2 = b[sortKey];
                 }
 
-                if (isNaN(val1)) {
+                if (val1 == null) val1 = "";
+                if (val2 == null) val2 = "";
+
+                if (isNumeric(val1) && isNumeric(val2)) {
+                    return (val1 - val2) * sortOrder;
+                } else {
                     var str1 = val1.toString();
                     var str2 = val2.toString();
 
                     return str1.localeCompare(str2) * sortOrder;
-                } else {
-                    return (val1 - val2) * sortOrder;
                 }
             });
         };

--- a/dist/amd/au-table.js
+++ b/dist/amd/au-table.js
@@ -199,10 +199,7 @@ define(["exports", "aurelia-framework"], function (exports, _aureliaFramework) {
         };
 
         AureliaTableCustomAttribute.prototype.doSort = function doSort(toSort, sortKey, sortOrder) {
-
-            var isNumeric = function isNumeric(n) {
-                return !isNaN(parseFloat(n)) && isFinite(n);
-            };
+            var _this2 = this;
 
             toSort.sort(function (a, b) {
 
@@ -220,7 +217,7 @@ define(["exports", "aurelia-framework"], function (exports, _aureliaFramework) {
                 if (val1 == null) val1 = "";
                 if (val2 == null) val2 = "";
 
-                if (isNumeric(val1) && isNumeric(val2)) {
+                if (_this2.isNumeric(val1) && _this2.isNumeric(val2)) {
                     return (val1 - val2) * sortOrder;
                 } else {
                     var str1 = val1.toString();
@@ -229,6 +226,10 @@ define(["exports", "aurelia-framework"], function (exports, _aureliaFramework) {
                     return str1.localeCompare(str2) * sortOrder;
                 }
             });
+        };
+
+        AureliaTableCustomAttribute.prototype.isNumeric = function isNumeric(toCheck) {
+            return !isNaN(parseFloat(toCheck)) && isFinite(toCheck);
         };
 
         AureliaTableCustomAttribute.prototype.doPaginate = function doPaginate(toPaginate) {
@@ -252,14 +253,14 @@ define(["exports", "aurelia-framework"], function (exports, _aureliaFramework) {
         };
 
         AureliaTableCustomAttribute.prototype.dataChanged = function dataChanged() {
-            var _this2 = this;
+            var _this3 = this;
 
             if (this.dataObserver) {
                 this.dataObserver.dispose();
             }
 
             this.dataObserver = this.bindingEngine.collectionObserver(this.data).subscribe(function () {
-                return _this2.applyPlugins();
+                return _this3.applyPlugins();
             });
 
             this.applyPlugins();

--- a/dist/commonjs/au-table.js
+++ b/dist/commonjs/au-table.js
@@ -196,6 +196,11 @@ var AureliaTableCustomAttribute = exports.AureliaTableCustomAttribute = (_dec = 
     };
 
     AureliaTableCustomAttribute.prototype.doSort = function doSort(toSort, sortKey, sortOrder) {
+
+        var isNumeric = function isNumeric(n) {
+            return !isNaN(parseFloat(n)) && isFinite(n);
+        };
+
         toSort.sort(function (a, b) {
 
             var val1 = void 0;
@@ -209,13 +214,16 @@ var AureliaTableCustomAttribute = exports.AureliaTableCustomAttribute = (_dec = 
                 val2 = b[sortKey];
             }
 
-            if (isNaN(val1)) {
+            if (val1 == null) val1 = "";
+            if (val2 == null) val2 = "";
+
+            if (isNumeric(val1) && isNumeric(val2)) {
+                return (val1 - val2) * sortOrder;
+            } else {
                 var str1 = val1.toString();
                 var str2 = val2.toString();
 
                 return str1.localeCompare(str2) * sortOrder;
-            } else {
-                return (val1 - val2) * sortOrder;
             }
         });
     };

--- a/dist/commonjs/au-table.js
+++ b/dist/commonjs/au-table.js
@@ -196,10 +196,7 @@ var AureliaTableCustomAttribute = exports.AureliaTableCustomAttribute = (_dec = 
     };
 
     AureliaTableCustomAttribute.prototype.doSort = function doSort(toSort, sortKey, sortOrder) {
-
-        var isNumeric = function isNumeric(n) {
-            return !isNaN(parseFloat(n)) && isFinite(n);
-        };
+        var _this2 = this;
 
         toSort.sort(function (a, b) {
 
@@ -217,7 +214,7 @@ var AureliaTableCustomAttribute = exports.AureliaTableCustomAttribute = (_dec = 
             if (val1 == null) val1 = "";
             if (val2 == null) val2 = "";
 
-            if (isNumeric(val1) && isNumeric(val2)) {
+            if (_this2.isNumeric(val1) && _this2.isNumeric(val2)) {
                 return (val1 - val2) * sortOrder;
             } else {
                 var str1 = val1.toString();
@@ -226,6 +223,10 @@ var AureliaTableCustomAttribute = exports.AureliaTableCustomAttribute = (_dec = 
                 return str1.localeCompare(str2) * sortOrder;
             }
         });
+    };
+
+    AureliaTableCustomAttribute.prototype.isNumeric = function isNumeric(toCheck) {
+        return !isNaN(parseFloat(toCheck)) && isFinite(toCheck);
     };
 
     AureliaTableCustomAttribute.prototype.doPaginate = function doPaginate(toPaginate) {
@@ -249,14 +250,14 @@ var AureliaTableCustomAttribute = exports.AureliaTableCustomAttribute = (_dec = 
     };
 
     AureliaTableCustomAttribute.prototype.dataChanged = function dataChanged() {
-        var _this2 = this;
+        var _this3 = this;
 
         if (this.dataObserver) {
             this.dataObserver.dispose();
         }
 
         this.dataObserver = this.bindingEngine.collectionObserver(this.data).subscribe(function () {
-            return _this2.applyPlugins();
+            return _this3.applyPlugins();
         });
 
         this.applyPlugins();

--- a/dist/es2015/au-table.js
+++ b/dist/es2015/au-table.js
@@ -156,11 +156,6 @@ export let AureliaTableCustomAttribute = (_dec = inject(BindingEngine), _dec2 = 
     }
 
     doSort(toSort, sortKey, sortOrder) {
-
-        let isNumeric = n => {
-            return !isNaN(parseFloat(n)) && isFinite(n);
-        };
-
         toSort.sort((a, b) => {
 
             let val1;
@@ -177,7 +172,7 @@ export let AureliaTableCustomAttribute = (_dec = inject(BindingEngine), _dec2 = 
             if (val1 == null) val1 = "";
             if (val2 == null) val2 = "";
 
-            if (isNumeric(val1) && isNumeric(val2)) {
+            if (this.isNumeric(val1) && this.isNumeric(val2)) {
                 return (val1 - val2) * sortOrder;
             } else {
                 let str1 = val1.toString();
@@ -186,6 +181,10 @@ export let AureliaTableCustomAttribute = (_dec = inject(BindingEngine), _dec2 = 
                 return str1.localeCompare(str2) * sortOrder;
             }
         });
+    }
+
+    isNumeric(toCheck) {
+        return !isNaN(parseFloat(toCheck)) && isFinite(toCheck);
     }
 
     doPaginate(toPaginate) {

--- a/dist/es2015/au-table.js
+++ b/dist/es2015/au-table.js
@@ -156,6 +156,11 @@ export let AureliaTableCustomAttribute = (_dec = inject(BindingEngine), _dec2 = 
     }
 
     doSort(toSort, sortKey, sortOrder) {
+
+        let isNumeric = n => {
+            return !isNaN(parseFloat(n)) && isFinite(n);
+        };
+
         toSort.sort((a, b) => {
 
             let val1;
@@ -169,13 +174,16 @@ export let AureliaTableCustomAttribute = (_dec = inject(BindingEngine), _dec2 = 
                 val2 = b[sortKey];
             }
 
-            if (isNaN(val1)) {
+            if (val1 == null) val1 = "";
+            if (val2 == null) val2 = "";
+
+            if (isNumeric(val1) && isNumeric(val2)) {
+                return (val1 - val2) * sortOrder;
+            } else {
                 let str1 = val1.toString();
                 let str2 = val2.toString();
 
                 return str1.localeCompare(str2) * sortOrder;
-            } else {
-                return (val1 - val2) * sortOrder;
             }
         });
     }

--- a/dist/system/au-table.js
+++ b/dist/system/au-table.js
@@ -204,6 +204,11 @@ System.register(["aurelia-framework"], function (_export, _context) {
                 };
 
                 AureliaTableCustomAttribute.prototype.doSort = function doSort(toSort, sortKey, sortOrder) {
+
+                    var isNumeric = function isNumeric(n) {
+                        return !isNaN(parseFloat(n)) && isFinite(n);
+                    };
+
                     toSort.sort(function (a, b) {
 
                         var val1 = void 0;
@@ -217,13 +222,16 @@ System.register(["aurelia-framework"], function (_export, _context) {
                             val2 = b[sortKey];
                         }
 
-                        if (isNaN(val1)) {
+                        if (val1 == null) val1 = "";
+                        if (val2 == null) val2 = "";
+
+                        if (isNumeric(val1) && isNumeric(val2)) {
+                            return (val1 - val2) * sortOrder;
+                        } else {
                             var str1 = val1.toString();
                             var str2 = val2.toString();
 
                             return str1.localeCompare(str2) * sortOrder;
-                        } else {
-                            return (val1 - val2) * sortOrder;
                         }
                     });
                 };

--- a/dist/system/au-table.js
+++ b/dist/system/au-table.js
@@ -204,10 +204,7 @@ System.register(["aurelia-framework"], function (_export, _context) {
                 };
 
                 AureliaTableCustomAttribute.prototype.doSort = function doSort(toSort, sortKey, sortOrder) {
-
-                    var isNumeric = function isNumeric(n) {
-                        return !isNaN(parseFloat(n)) && isFinite(n);
-                    };
+                    var _this2 = this;
 
                     toSort.sort(function (a, b) {
 
@@ -225,7 +222,7 @@ System.register(["aurelia-framework"], function (_export, _context) {
                         if (val1 == null) val1 = "";
                         if (val2 == null) val2 = "";
 
-                        if (isNumeric(val1) && isNumeric(val2)) {
+                        if (_this2.isNumeric(val1) && _this2.isNumeric(val2)) {
                             return (val1 - val2) * sortOrder;
                         } else {
                             var str1 = val1.toString();
@@ -234,6 +231,10 @@ System.register(["aurelia-framework"], function (_export, _context) {
                             return str1.localeCompare(str2) * sortOrder;
                         }
                     });
+                };
+
+                AureliaTableCustomAttribute.prototype.isNumeric = function isNumeric(toCheck) {
+                    return !isNaN(parseFloat(toCheck)) && isFinite(toCheck);
                 };
 
                 AureliaTableCustomAttribute.prototype.doPaginate = function doPaginate(toPaginate) {
@@ -257,14 +258,14 @@ System.register(["aurelia-framework"], function (_export, _context) {
                 };
 
                 AureliaTableCustomAttribute.prototype.dataChanged = function dataChanged() {
-                    var _this2 = this;
+                    var _this3 = this;
 
                     if (this.dataObserver) {
                         this.dataObserver.dispose();
                     }
 
                     this.dataObserver = this.bindingEngine.collectionObserver(this.data).subscribe(function () {
-                        return _this2.applyPlugins();
+                        return _this3.applyPlugins();
                     });
 
                     this.applyPlugins();

--- a/src/au-table.js
+++ b/src/au-table.js
@@ -120,9 +120,6 @@ export class AureliaTableCustomAttribute {
     }
 
     doSort(toSort, sortKey, sortOrder) {
-
-        let isNumeric = (n) => {return !isNaN(parseFloat(n)) && isFinite(n);}
-
         toSort.sort((a, b) => {
 
             let val1;
@@ -139,7 +136,7 @@ export class AureliaTableCustomAttribute {
             if(val1 == null) val1 = "";
             if(val2 == null) val2 = "";
 
-            if (isNumeric(val1) && isNumeric(val2)) {               
+            if (this.isNumeric(val1) && this.isNumeric(val2)) {               
                 return (val1 - val2) * sortOrder;
             } else {
                 let str1 = val1.toString();
@@ -148,6 +145,10 @@ export class AureliaTableCustomAttribute {
                 return str1.localeCompare(str2) * sortOrder;
             }
         });
+    }
+
+    isNumeric(toCheck){
+        return !isNaN(parseFloat(toCheck)) && isFinite(toCheck);
     }
 
     doPaginate(toPaginate) {

--- a/src/au-table.js
+++ b/src/au-table.js
@@ -120,6 +120,9 @@ export class AureliaTableCustomAttribute {
     }
 
     doSort(toSort, sortKey, sortOrder) {
+
+        let isNumeric = (n) => {return !isNaN(parseFloat(n)) && isFinite(n);}
+
         toSort.sort((a, b) => {
 
             let val1;
@@ -133,16 +136,17 @@ export class AureliaTableCustomAttribute {
                 val2 = b[sortKey];
             }
 
+            if(val1 == null) val1 = "";
+            if(val2 == null) val2 = "";
 
-            if (isNaN(val1)) {
+            if (isNumeric(val1) && isNumeric(val2)) {               
+                return (val1 - val2) * sortOrder;
+            } else {
                 let str1 = val1.toString();
                 let str2 = val2.toString();
 
                 return str1.localeCompare(str2) * sortOrder;
-            } else {
-                return (val1 - val2) * sortOrder;
             }
-
         });
     }
 


### PR DESCRIPTION
Make sure you check this one out before accepting.

The issues I was having with the sort was this:  

* If my table data had a property where the values were numeric and string, like "a", "31", "", "301" then depending on which one was compared first, they were incorrectly compared as a number `"" == "a"`, or as a string "31 comes after 301".
* `isNaN` was pretty loose with what was a number.  For example, "$1 off!" was considered a number on one of the browsers I'm testing with
* null values would stop the sort immediately with the array partially sorted

So what this does is alter the sort to:

1.  Make the test for numeric much more discriminating.
1.  Only compare two values as numbers if *both* are numbers
1.  Replace null with an empty string just before the comparison.


Please let me know your thoughts.
