### PR TITLE
Add row selected event for curious listeners

### DIFF
--- a/dist/amd/au-table-select.js
+++ b/dist/amd/au-table-select.js
@@ -116,6 +116,26 @@ define(["exports", "aurelia-framework", "./au-table"], function (exports, _aurel
 
             this.row.$IsSelected = this.row.$IsSelected ? false : true;
             this.setClass();
+
+            if (this.row.$IsSelected) {
+                this.dispatchSelectedEvent();
+            }
+        };
+
+        AutSelectCustomAttribute.prototype.dispatchSelectedEvent = function dispatchSelectedEvent() {
+            var selectedEvent = {};
+            if (window.CustomEvent) {
+                selectedEvent = new CustomEvent('select', {
+                    detail: { row: this.row },
+                    bubbles: true
+                });
+            } else {
+                selectedEvent = document.createEvent('CustomEvent');
+                selectedEvent.initCustomEvent('select', true, true, {
+                    detail: { row: this.row }
+                });
+            }
+            this.element.dispatchEvent(selectedEvent);
         };
 
         AutSelectCustomAttribute.prototype.isSelectedChanged = function isSelectedChanged() {

--- a/dist/commonjs/au-table-select.js
+++ b/dist/commonjs/au-table-select.js
@@ -115,6 +115,26 @@ var AutSelectCustomAttribute = exports.AutSelectCustomAttribute = (_dec = (0, _a
 
         this.row.$IsSelected = this.row.$IsSelected ? false : true;
         this.setClass();
+
+        if (this.row.$IsSelected) {
+            this.dispatchSelectedEvent();
+        }
+    };
+
+    AutSelectCustomAttribute.prototype.dispatchSelectedEvent = function dispatchSelectedEvent() {
+        var selectedEvent = {};
+        if (window.CustomEvent) {
+            selectedEvent = new CustomEvent('select', {
+                detail: { row: this.row },
+                bubbles: true
+            });
+        } else {
+            selectedEvent = document.createEvent('CustomEvent');
+            selectedEvent.initCustomEvent('select', true, true, {
+                detail: { row: this.row }
+            });
+        }
+        this.element.dispatchEvent(selectedEvent);
     };
 
     AutSelectCustomAttribute.prototype.isSelectedChanged = function isSelectedChanged() {

--- a/dist/es2015/au-table-select.js
+++ b/dist/es2015/au-table-select.js
@@ -98,6 +98,26 @@ export let AutSelectCustomAttribute = (_dec = inject(AureliaTableCustomAttribute
 
         this.row.$IsSelected = this.row.$IsSelected ? false : true;
         this.setClass();
+
+        if (this.row.$IsSelected) {
+            this.dispatchSelectedEvent();
+        }
+    }
+
+    dispatchSelectedEvent() {
+        let selectedEvent = {};
+        if (window.CustomEvent) {
+            selectedEvent = new CustomEvent('select', {
+                detail: { row: this.row },
+                bubbles: true
+            });
+        } else {
+            selectedEvent = document.createEvent('CustomEvent');
+            selectedEvent.initCustomEvent('select', true, true, {
+                detail: { row: this.row }
+            });
+        }
+        this.element.dispatchEvent(selectedEvent);
     }
 
     isSelectedChanged() {

--- a/dist/system/au-table-select.js
+++ b/dist/system/au-table-select.js
@@ -123,6 +123,26 @@ System.register(["aurelia-framework", "./au-table"], function (_export, _context
 
                     this.row.$IsSelected = this.row.$IsSelected ? false : true;
                     this.setClass();
+
+                    if (this.row.$IsSelected) {
+                        this.dispatchSelectedEvent();
+                    }
+                };
+
+                AutSelectCustomAttribute.prototype.dispatchSelectedEvent = function dispatchSelectedEvent() {
+                    var selectedEvent = {};
+                    if (window.CustomEvent) {
+                        selectedEvent = new CustomEvent('select', {
+                            detail: { row: this.row },
+                            bubbles: true
+                        });
+                    } else {
+                        selectedEvent = document.createEvent('CustomEvent');
+                        selectedEvent.initCustomEvent('select', true, true, {
+                            detail: { row: this.row }
+                        });
+                    }
+                    this.element.dispatchEvent(selectedEvent);
                 };
 
                 AutSelectCustomAttribute.prototype.isSelectedChanged = function isSelectedChanged() {

--- a/src/au-table-select.js
+++ b/src/au-table-select.js
@@ -9,7 +9,7 @@ export class AutSelectCustomAttribute {
     @bindable selectedClass = 'aut-row-selected';
 
     selectedSubscription;
-
+    
     constructor(auTable, element, bindingEngine) {
         this.auTable = auTable;
         this.element = element;
@@ -26,7 +26,7 @@ export class AutSelectCustomAttribute {
 
         this.selectedSubscription = this.bindingEngine.propertyObserver(this.row, '$IsSelected').subscribe(() => this.isSelectedChanged());
 
-        this.setClass();
+        this.setClass();        
     }
 
     detached() {
@@ -42,7 +42,7 @@ export class AutSelectCustomAttribute {
         }
     }
 
-    handleRowSelected(e) {
+    handleRowSelected(e) {        
         let source = event.target || event.srcElement;
         if (source.tagName.toLowerCase() !== 'td') {
             return;
@@ -51,9 +51,29 @@ export class AutSelectCustomAttribute {
         if(this.mode === 'single'){
             this.deselectAll();
         }
-        
+                
         this.row.$IsSelected = this.row.$IsSelected ? false : true;
         this.setClass();
+
+        if( this.row.$IsSelected){
+            this.dispatchSelectedEvent();
+        }
+    }    
+
+    dispatchSelectedEvent(){
+        let selectedEvent = {};
+        if(window.CustomEvent){
+            selectedEvent = new CustomEvent('select', {
+                    detail:{ row: this.row }, 
+                    bubbles: true
+                });
+        } else{
+            selectedEvent = document.createEvent('CustomEvent');
+            selectedEvent.initCustomEvent('select', true, true, {
+                detail: { row: this.row}
+                });            
+        }
+        this.element.dispatchEvent(selectedEvent);
     }
 
     isSelectedChanged() {


### PR DESCRIPTION
If you want this type of functionality included.   This pull request makes `aut-select` add an event to the `<tr>` element it is attached to. The event fires when a row goes from unselected to selected.  It can be used like this:

    <tr repeat.for="x in $displayData" aut-select="row.bind: x" select.delegate="rowSelected($event)">

Where `rowSelected` is a function on an accessible scope.  

I went with an event over a callback based on [this excellent blog posting](http://ilikekillnerds.com/2015/08/aurelia-custom-elements-custom-callback-events-tutorial/), although it is a year old now.

Feel free to merge it if you like it, but no worries if you reject it if you want to go another way.  I like this because it allows me to perform validation or other logic on a selected row in my viewmodel code, without having to attach a listener to the `$isSelected` property.

(sorry about a few bits of whitespace in aut-table-select.js.  I can't find where they're coming from.  Platform or editor issues, I suppose)