### PR TITLE
Allow empty au-sort attribute

### DIFF
--- a/src/au-table-sort.js
+++ b/src/au-table-sort.js
@@ -36,18 +36,16 @@ export class AutSortCustomAttribute {
   }
 
   attached() {
-    if (this.key === null && this.custom === null) {
-      throw new Error('Must provide a key or a custom sort function.');
+    if (this.key || this.custom ) {
+      this.element.style.cursor = 'pointer';
+      this.element.classList.add('aut-sort');
+
+      this.element.addEventListener('click', this.rowSelectedListener);
+      this.auTable.addSortChangedListener(this.sortChangedListener);
+
+      this.handleDefault();
+      this.setClass();
     }
-
-    this.element.style.cursor = 'pointer';
-    this.element.classList.add('aut-sort');
-
-    this.element.addEventListener('click', this.rowSelectedListener);
-    this.auTable.addSortChangedListener(this.sortChangedListener);
-
-    this.handleDefault();
-    this.setClass();
   }
 
   detached() {


### PR DESCRIPTION
This change allows table columns to be generated using an iterator. For example (using PUG notation):
```th(repeat.for='col of cols' aut-sort='key.bind: col.sortField')```
can leave it up to individual columns to decide whether there is a key to be bound. 
The workaround is to declare two ```th``` attributes, one with ```if.bind='col.sortField'``` and the other without.
Summary: I think throwing an exception is not necessary. Just ignore the attribute if it doesn't contain a key nor custom attribute.