### PR TITLE
Prevent error when sorted object property is undefined

### DIFF
--- a/src/au-table.js
+++ b/src/au-table.js
@@ -171,8 +171,9 @@ export class AureliaTableCustomAttribute {
         val2 = this.getPropertyValue(b, this.sortKey);
       }
 
-      if (val1 === null) val1 = '';
-      if (val2 === null) val2 = '';
+      // accounting for null and undefined properties
+      if (val1 == null) val1 = '';
+      if (val2 == null) val2 = '';
 
       if (this.isNumeric(val1) && this.isNumeric(val2)) {
         return (val1 - val2) * this.sortOrder;

--- a/src/au-table.js
+++ b/src/au-table.js
@@ -172,8 +172,8 @@ export class AureliaTableCustomAttribute {
       }
 
       // accounting for null and undefined properties
-      if (val1 == null) val1 = '';
-      if (val2 == null) val2 = '';
+      if (val1 === null || val1 === undefined) val1 = '';
+      if (val2 === null || val2 === undefined) val2 = '';
 
       if (this.isNumeric(val1) && this.isNumeric(val2)) {
         return (val1 - val2) * this.sortOrder;


### PR DESCRIPTION
In the event that a sorted property value resolved to undefined the code had attempted to call .toString() which resulted in an error.

This change should account for both null and undefined properties, setting the value to empty string in both cases.